### PR TITLE
Add Atmega3208 support

### DIFF
--- a/TurntableFunctions.cpp
+++ b/TurntableFunctions.cpp
@@ -25,7 +25,14 @@
 
 #include "TurntableFunctions.h"
 #include "IOFunctions.h"
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 #include "atmega328p_pins.h"
+#endif
+
+#if defined(__AVR_ATmegax08__)
+#include "atmega3208_pins.h"
+#endif
+
 const long sanitySteps = SANITY_STEPS;         // Define an arbitrary number of steps to prevent indefinite spinning if homing/calibrations fails.
 const long homeSensitivity = HOME_SENSITIVITY; // Define the minimum number of steps required before homing sensor deactivates.
 const int16_t totalMinutes = 21600;            // Total minutes in one rotation (360 * 60)

--- a/atmega3208_pins.h
+++ b/atmega3208_pins.h
@@ -4,8 +4,3 @@ const uint8_t relay1Pin = 3;      // Control pin for relay 1.
 const uint8_t relay2Pin = 4;      // Control pin for relay 2.
 const uint8_t ledPin = 6;         // Pin for LED output.
 const uint8_t accPin = 7;         // Pin for accessory output.
-
-const uint8_t STEPPER_PIN_0 = A3;
-const uint8_t STEPPER_PIN_1 = A1;
-const uint8_t STEPPER_PIN_2 = A2;
-const uint8_t STEPPER_PIN_3 = A0;

--- a/atmega3208_pins.h
+++ b/atmega3208_pins.h
@@ -7,4 +7,9 @@ const uint8_t relay1Pin = PIN_PD7;      // Control pin for relay 1.
 const uint8_t relay2Pin = PIN_PD6;      // Control pin for relay 2.
 const uint8_t ledPin = PIN_PD5;         // Pin for LED output.
 const uint8_t accPin = PIN_PD4;         // Pin for accessory output.
+
+const uint8_t STEPPER_PIN_0 = PIN_PA7;
+const uint8_t STEPPER_PIN_1 = PIN_PC0;
+const uint8_t STEPPER_PIN_2 = PIN_PC1;
+const uint8_t STEPPER_PIN_3 = PIN_PC2;
 #endif

--- a/atmega3208_pins.h
+++ b/atmega3208_pins.h
@@ -1,6 +1,10 @@
-const uint8_t limitSensorPin = 2; // Define pin 2 for the traverser mode limit sensor.
-const uint8_t homeSensorPin = 5;  // Define pin 5 for the home sensor.
-const uint8_t relay1Pin = 3;      // Control pin for relay 1.
-const uint8_t relay2Pin = 4;      // Control pin for relay 2.
-const uint8_t ledPin = 6;         // Pin for LED output.
-const uint8_t accPin = 7;         // Pin for accessory output.
+#pragma once
+#ifndef PIN_DEFINITIONS_H
+#define PIN_DEFINITIONS_H
+const uint8_t limitSensorPin = PIN_PA5; // Define pin 2 for the traverser mode limit sensor.
+const uint8_t homeSensorPin = PIN_PA6;  // Define pin 5 for the home sensor.
+const uint8_t relay1Pin = PIN_PD7;      // Control pin for relay 1.
+const uint8_t relay2Pin = PIN_PD6;      // Control pin for relay 2.
+const uint8_t ledPin = PIN_PD5;         // Pin for LED output.
+const uint8_t accPin = PIN_PD4;         // Pin for accessory output.
+#endif

--- a/atmega328p_pins.h
+++ b/atmega328p_pins.h
@@ -1,3 +1,6 @@
+#pragma once
+#ifndef PIN_DEFINITIONS_H
+#define PIN_DEFINITIONS_H
 const uint8_t limitSensorPin = 2; // Define pin 2 for the traverser mode limit sensor.
 const uint8_t homeSensorPin = 5;  // Define pin 5 for the home sensor.
 const uint8_t relay1Pin = 3;      // Control pin for relay 1.
@@ -9,3 +12,4 @@ const uint8_t STEPPER_PIN_0 = A3;
 const uint8_t STEPPER_PIN_1 = A1;
 const uint8_t STEPPER_PIN_2 = A2;
 const uint8_t STEPPER_PIN_3 = A0;
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,3 +35,10 @@ board = uno
 framework = arduino
 monitor_speed = 115200
 monitor_echo = yes
+
+[env:ATmega3208]
+platform = atmelmegaavr
+board = ATmega3208
+framework = arduino
+monitor_speed = 115200
+monitor_echo = yes

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 default_envs = 
 	nanoatmega328new
 	uno
+	ATmega3208
 src_dir = .
 include_dir = .
 

--- a/standard_steppers.h
+++ b/standard_steppers.h
@@ -9,7 +9,7 @@
 
 #include <Arduino.h>
 #include "AccelStepper.h"
-#include "atmegSTEPPER_PIN_028p_pins.h"
+#include "atmega328p_pins.h"
 
 #define UNUSED_PIN 127
 

--- a/standard_steppers.h
+++ b/standard_steppers.h
@@ -9,7 +9,13 @@
 
 #include <Arduino.h>
 #include "AccelStepper.h"
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)
 #include "atmega328p_pins.h"
+#endif
+
+#if defined(__AVR_ATmegax08__)
+#include "atmega3208_pins.h"
+#endif
 
 #define UNUSED_PIN 127
 

--- a/standard_steppers.h
+++ b/standard_steppers.h
@@ -2,22 +2,23 @@
  *  © 2022 Peter Cole
  *
  *  These are the standard stepper controller and motor definitions.
-*/
+ */
 
 #ifndef STANDARD_STEPPERS_h
 #define STANDARD_STEPPERS_h
 
 #include <Arduino.h>
 #include "AccelStepper.h"
+#include "atmegSTEPPER_PIN_028p_pins.h"
 
 #define UNUSED_PIN 127
 
 #define FULLSTEPS 4096
 
-#define ULN2003_HALF_CW AccelStepper(AccelStepper::HALF4WIRE, A3, A1, A2, A0)
-#define ULN2003_HALF_CCW AccelStepper(AccelStepper::HALF4WIRE, A0, A2, A1, A3)
-#define ULN2003_FULL_CW AccelStepper(AccelStepper::FULL4WIRE, A3, A1, A2, A0)
-#define ULN2003_FULL_CCW AccelStepper(AccelStepper::FULL4WIRE, A0, A2, A1, A3)
-#define A4988 AccelStepper(AccelStepper::DRIVER, A0, A1)
+#define ULN2003_HALF_CW AccelStepper(AccelStepper::HALF4WIRE, STEPPER_PIN_0, STEPPER_PIN_1, STEPPER_PIN_2, STEPPER_PIN_3)
+#define ULN2003_HALF_CCW AccelStepper(AccelStepper::HALF4WIRE, STEPPER_PIN_3, STEPPER_PIN_2, STEPPER_PIN_1, STEPPER_PIN_0)
+#define ULN2003_FULL_CW AccelStepper(AccelStepper::FULL4WIRE, STEPPER_PIN_0, STEPPER_PIN_1, STEPPER_PIN_2, STEPPER_PIN_3)
+#define ULN2003_FULL_CCW AccelStepper(AccelStepper::FULL4WIRE, STEPPER_PIN_3, STEPPER_PIN_2, STEPPER_PIN_1, STEPPER_PIN_0)
+#define A4988 AccelStepper(AccelStepper::DRIVER, STEPPER_PIN_3, STEPPER_PIN_1)
 
 #endif


### PR DESCRIPTION
This PR is to allow the DCC-EX Turntable code to be used on the AtMega3208 microcontroller.